### PR TITLE
fix: Handle exceptions raised by `request.urlopen` in `HttpClient.post`

### DIFF
--- a/src/amplitude/http_client.py
+++ b/src/amplitude/http_client.py
@@ -2,7 +2,7 @@ import json
 from enum import Enum
 from socket import timeout
 from typing import Optional
-from urllib import request, response
+from urllib import request, response, error
 
 from amplitude import constants
 
@@ -134,4 +134,14 @@ class HttpClient:
         except timeout:
             result.code = 408
             result.status = HttpStatus.TIMEOUT
+        except error.HTTPError as e:
+            try:
+                result.parse(e)
+            except:
+                result = Response()
+                result.code = e.code
+                result.status = Response.get_status(e.code)
+                result.body = {'error': e.reason}
+        except error.URLError as e:
+            result.body = {'error': str(e.reason)}
         return result

--- a/src/amplitude/processor.py
+++ b/src/amplitude/processor.py
@@ -55,7 +55,7 @@ class ResponseProcessor:
             self.push_to_storage(events_for_retry_delay, 30000, res)
             self.push_to_storage(events_for_retry, 0, res)
         else:
-            self.callback(events, res.code, "Unknown error")
+            self.callback(events, res.code, res.error or "Unknown error")
 
     def push_to_storage(self, events, delay, res):
         for event in events:


### PR DESCRIPTION
### Summary

At the moment the sad path is essentially non-functional, as `request.urlopen` raises `HTTPError` exceptions for responses with status code 400...500. This PR fixes buggy exception handling in `HttpClient.post` function making it work as expected.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Python/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No