### PR TITLE
fix: use new thread instead of background blocking thread

### DIFF
--- a/src/amplitude/plugin.py
+++ b/src/amplitude/plugin.py
@@ -88,8 +88,7 @@ class AmplitudeDestinationPlugin(DestinationPlugin):
         self.configuration = client.configuration
         self.storage = client.configuration.get_storage()
         self.workers.setup(client.configuration, self.storage)
-        self.storage.setup(client.configuration)
-        self.workers.start()
+        self.storage.setup(client.configuration, self.workers)
 
     def execute(self, event: BaseEvent) -> None:
         event = self.timeline.process(event)

--- a/src/amplitude/worker.py
+++ b/src/amplitude/worker.py
@@ -1,6 +1,6 @@
 import json
 from concurrent.futures import ThreadPoolExecutor
-from threading import Thread
+from threading import Thread, RLock
 
 from amplitude.exception import InvalidAPIKeyError
 from amplitude.http_client import HttpClient
@@ -12,7 +12,8 @@ class Workers:
     def __init__(self):
         self.threads_pool = ThreadPoolExecutor(max_workers=16)
         self.is_active = True
-        self.consumer = Thread(target=self.buffer_consumer)
+        self.consumer_lock = RLock()
+        self.is_started = False
         self.configuration = None
         self.storage = None
         self.response_processor = ResponseProcessor(self)
@@ -23,18 +24,22 @@ class Workers:
         self.response_processor.setup(configuration, storage)
 
     def start(self):
-        self.consumer.start()
+        with self.consumer_lock:
+            if not self.is_started:
+                self.is_started = True
+                consumer = Thread(target=self.buffer_consumer)
+                consumer.start()
 
     def stop(self):
         self.flush()
         self.is_active = False
-        self.consumer.join()
+        self.is_started = True
         self.threads_pool.shutdown()
 
     def flush(self):
         events = self.storage.pull_all()
         if events:
-            self.send(events)
+            self.threads_pool.submit(self.send, events)
 
     def send(self, events):
         url = self.configuration.server_url
@@ -59,12 +64,18 @@ class Workers:
         return json.dumps(payload_body).encode('utf8')
 
     def buffer_consumer(self):
-        while self.is_active:
+        if self.is_active:
             with self.storage.lock:
-                events = self.storage.pull(self.configuration.flush_queue_size)
-                if events:
-                    self.threads_pool.submit(self.send, events)
-                else:
-                    wait_time = self.storage.wait_time / 1000
-                    if wait_time > 0:
-                        self.storage.lock.wait(wait_time)
+                self.storage.lock.wait(self.configuration.flush_interval_millis / 1000)
+                while True:
+                    if not self.storage.total_events:
+                        break
+                    events = self.storage.pull(self.configuration.flush_queue_size)
+                    if events:
+                        self.threads_pool.submit(self.send, events)
+                    else:
+                        wait_time = self.storage.wait_time / 1000
+                        if wait_time > 0:
+                            self.storage.lock.wait(wait_time)
+        with self.consumer_lock:
+            self.is_started = False


### PR DESCRIPTION
### Summary

1. create new consumer thread when event pushed to storage
2. remove old background blocking consumer thread

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Python/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no