### PR TITLE
fix: set correct fetch-depth for semantic release

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
       - name: Checkout for release to PyPI
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Set up Python 3.7
         uses: actions/setup-python@v3


### PR DESCRIPTION
### Summary

set fetch-depth to 0 for checkout action

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Python/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no