### PR TITLE
fix: set_group put group_type/group_name in groups attribute

### DIFF
--- a/src/amplitude/client.py
+++ b/src/amplitude/client.py
@@ -4,7 +4,7 @@ Classes:
     Amplitude: the Amplitude client class
 """
 
-from typing import Optional, Union, List
+from typing import Optional, Union, List, Final
 
 from amplitude.config import Config
 from amplitude.event import Revenue, BaseEvent, Identify, IdentifyEvent, GroupIdentifyEvent, EventOptions
@@ -43,7 +43,7 @@ class Amplitude:
             configuration (amplitude.config.Config, optional): The configuration of client instance. A new instance
                 with default config value will be used by default.
         """
-        self.configuration: Config = configuration
+        self.configuration: Final[Config] = configuration
         self.configuration.api_key = api_key
         self.__timeline = Timeline()
         self.__timeline.setup(self)
@@ -125,9 +125,9 @@ class Amplitude:
             event_options (amplitude.event.EventOptions): Provide additional information for event
                 like user_id.
         """
-        identify_obj = Identify()
-        identify_obj.set(group_type, group_name)
-        self.identify(identify_obj, event_options)
+        event = IdentifyEvent(groups={group_type: group_name})
+        event.load_event_options(event_options)
+        self.track(event)
 
     def flush(self):
         """Flush all event waiting to be sent in the buffer"""

--- a/src/amplitude/client.py
+++ b/src/amplitude/client.py
@@ -4,7 +4,7 @@ Classes:
     Amplitude: the Amplitude client class
 """
 
-from typing import Optional, Union, List, Final
+from typing import Optional, Union, List
 
 from amplitude.config import Config
 from amplitude.event import Revenue, BaseEvent, Identify, IdentifyEvent, GroupIdentifyEvent, EventOptions
@@ -43,7 +43,7 @@ class Amplitude:
             configuration (amplitude.config.Config, optional): The configuration of client instance. A new instance
                 with default config value will be used by default.
         """
-        self.configuration: Final[Config] = configuration
+        self.configuration: Config = configuration
         self.configuration.api_key = api_key
         self.__timeline = Timeline()
         self.__timeline.setup(self)

--- a/src/test/test_client.py
+++ b/src/test/test_client.py
@@ -174,11 +174,11 @@ class AmplitudeClientTestCase(unittest.TestCase):
         def callback_func(event, code, message=None):
             self.assertEqual(200, code)
             self.assertTrue(isinstance(event, IdentifyEvent))
-            self.assertTrue("user_properties" in event)
+            self.assertTrue("groups" in event)
             self.assertEqual("$identify", event["event_type"])
             self.assertEqual("test_user_id", event["user_id"])
             self.assertEqual("test_device_id", event["device_id"])
-            self.assertEqual({"$set": {"type": ["test_group", "test_group_2"]}}, event.user_properties)
+            self.assertEqual({"type": ["test_group", "test_group_2"]}, event.groups)
 
         self.client.configuration.callback = callback_func
         for use_batch in (True, False):


### PR DESCRIPTION
### Summary

Put group_type and group_name in groups attributes of IdentifyEvent instead of user_properties.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Python/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no