### PR TITLE
feat: add ingestion_metadata field

### DIFF
--- a/examples/flask_example/flaskapp.py
+++ b/examples/flask_example/flaskapp.py
@@ -48,7 +48,7 @@ def track_revenue(user_id):
 @app.route("/flush")
 def flush_event():
     amp_client.flush()
-    return f"<p>All events flushed</p>"
+    return "<p>All events flushed</p>"
 
 
 if __name__ == "__main__":

--- a/src/amplitude/__init__.py
+++ b/src/amplitude/__init__.py
@@ -3,7 +3,7 @@
 
 from amplitude.client import Amplitude
 from amplitude.event import BaseEvent, EventOptions, Identify, Revenue, IdentifyEvent, \
-    GroupIdentifyEvent, RevenueEvent, Plan
+    GroupIdentifyEvent, RevenueEvent, Plan, IngestionMetadata
 from amplitude.config import Config
 from amplitude.constants import PluginType
 from amplitude.plugin import EventPlugin, DestinationPlugin

--- a/src/amplitude/config.py
+++ b/src/amplitude/config.py
@@ -8,7 +8,7 @@ import logging
 from typing import Optional, Callable
 
 from amplitude import constants
-from amplitude.event import BaseEvent, Plan
+from amplitude.event import BaseEvent, Plan, IngestionMetadata
 from amplitude.storage import InMemoryStorageProvider, StorageProvider, Storage
 
 
@@ -33,6 +33,7 @@ class Config:
         storage_provider (amplitude.storage.StorageProvider, optional): Default to InMemoryStorageProvider.
             Provide storage instance for events buffer.
         plan (amplitude.event.Plan, optional): Tracking plan information. Default to None.
+        ingestion_metadata (amplitude.event.IngestionMetadata, optional): Ingestion metadata. Default to None.
 
     Properties:
         options: A dictionary contains minimum id length information. None if min_id_length not set.
@@ -55,7 +56,8 @@ class Config:
                  use_batch: bool = False,
                  server_url: Optional[str] = None,
                  storage_provider: StorageProvider = InMemoryStorageProvider(),
-                 plan: Plan = None):
+                 plan: Plan = None,
+                 ingestion_metadata: IngestionMetadata = None):
         """The constructor of Config class"""
         self.api_key: str = api_key
         self._flush_queue_size: int = flush_queue_size
@@ -71,6 +73,7 @@ class Config:
         self.storage_provider: StorageProvider = storage_provider
         self.opt_out: bool = False
         self.plan: Plan = plan
+        self.ingestion_metadata: IngestionMetadata = ingestion_metadata
 
     def get_storage(self) -> Storage:
         """Use configured StorageProvider to create a Storage instance then return.

--- a/src/amplitude/plugin.py
+++ b/src/amplitude/plugin.py
@@ -179,8 +179,10 @@ class ContextPlugin(Plugin):
 
     Methods:
         apply_context_data(event): Add SDK name and version to event.library.
-        execute(event): Set event default timestamp and insert_id if not set elsewhere.
-            Add SDK name and version to event.library.
+        execute(event):
+            - Set event default timestamp and insert_id if not set elsewhere.
+            - Add SDK name and version to event.library.
+            - Mount plan, ingestion_metadata if not yet.
     """
 
     def __init__(self):
@@ -201,7 +203,10 @@ class ContextPlugin(Plugin):
         event.library = self.context_string
 
     def execute(self, event: BaseEvent) -> BaseEvent:
-        """Set event default timestamp and insert_id if not set elsewhere. Add SDK name and version to event.library.
+        """
+        - Set event default timestamp and insert_id if not set elsewhere.
+        - Add SDK name and version to event.library.
+        - Mount plan, ingestion_metadata if not yet.
 
         Args:
             event (BaseEvent): The event to be processed.
@@ -212,6 +217,8 @@ class ContextPlugin(Plugin):
             event["insert_id"] = str(uuid.uuid4())
         if self.configuration.plan and (not event.plan):
             event["plan"] = self.configuration.plan
+        if self.configuration.ingestion_metadata and (not event.ingestion_metadata):
+            event["ingestion_metadata"] = self.configuration.ingestion_metadata
         self.apply_context_data(event)
         return event
 


### PR DESCRIPTION
### Summary
- feat: add ingestion_metadata field

Add this option in the configuration, which can be used in the library wrapper/code generation/dynamic loading cases, for setting the `ingestion_metadata` information.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Python/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No