### PR TITLE
fix: Add a optional grace time period to shutdown method

### DIFF
--- a/src/amplitude/client.py
+++ b/src/amplitude/client.py
@@ -3,7 +3,7 @@
 Classes:
     Amplitude: the Amplitude client class
 """
-
+import time
 from typing import Optional, Union, List
 
 from amplitude.config import Config
@@ -163,7 +163,9 @@ class Amplitude:
         self.__timeline.remove(plugin)
         return self
 
-    def shutdown(self):
+    def shutdown(self, grace_time_milliseconds=0):
         """Shutdown the client instance, not accepting new events, flush all events in buffer"""
         self.configuration.opt_out = True
         self.__timeline.shutdown()
+        if grace_time_milliseconds > 0:
+            time.sleep(grace_time_milliseconds / 1000)

--- a/src/test/test_client.py
+++ b/src/test/test_client.py
@@ -15,7 +15,7 @@ class AmplitudeClientTestCase(unittest.TestCase):
                                 configuration=Config(flush_queue_size=10, flush_interval_millis=500))
 
     def tearDown(self) -> None:
-        self.client.shutdown()
+        self.client.shutdown(100)
 
     def test_amplitude_client_track_success(self):
         post_method = MagicMock()


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude Python SDK! 🐍

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Add optional parameter: grace_time_milliseconds to client.shutdown()
Allow user to delay main interpreter thread close waiting the last batch events task scheduled to threads pool. 

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Python/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no