### PR TITLE
test(event): Add test with `none` in event_properties

### DIFF
--- a/src/test/test_event.py
+++ b/src/test/test_event.py
@@ -153,6 +153,14 @@ class AmplitudeEventTestCase(unittest.TestCase):
         expect_dict["event_properties"] = {"bool_properties": bool_properties}
         self.assertEqual(expect_dict, event.get_event_body())
 
+    def test_base_event_set_none_in_dict_attributes_success(self):
+        event = BaseEvent(event_type="test_event", user_id="test_user")
+        expect_dict = {"event_type": "test_event", "user_id": "test_user"}
+        none_properties = None
+        event["event_properties"] = {"none_properties": none_properties}
+        expect_dict["event_properties"] = {"none_properties": none_properties}
+        self.assertEqual(expect_dict, event.get_event_body())
+
     def test_base_event_set_numeric_in_dict_attributes_success(self):
         event = BaseEvent(event_type="test_event", user_id="test_user")
         expect_dict = {"event_type": "test_event", "user_id": "test_user"}


### PR DESCRIPTION
### Summary

Adds a test which have none as one of the values in the dict given to event_properties of a BaseEvent. This test fails, while I wouldn't necessarily expect that. Is this a bug?

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Python/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?: no