### PR TITLE
chore: fix semantic release package version

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -41,13 +41,13 @@ jobs:
       - name: Publish distribution PyPI --dry-run
         if: ${{ github.event.inputs.dryRun == 'true'}}
         run: |
-          python -m pip install python-semantic-release
+          python -m pip install python-semantic-release~=7.0.0
           semantic-release publish --noop
 
       - name: Publish distribution PyPI
         if: ${{ github.event.inputs.dryRun == 'false'}}
         run: |
-          python -m pip install python-semantic-release
+          python -m pip install python-semantic-release~=7.0.0
           git config user.name amplitude-sdk-bot
           git config user.email amplitude-sdk-bot@users.noreply.github.com
           semantic-release publish


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude Python SDK! 🐍

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Latest `python-semantic-release` is `8.0.4` which 
- returns an error `No such option: --noop` when running `semantic-release publish --noop`. (failed github action)
- returns no error but didn't go through following steps ([non-dry run](https://github.com/amplitude/Amplitude-Python/actions/runs/5756461858/job/15605914463))

Fix the package version to the nearest compatible one
<img width="566" alt="image" src="https://github.com/amplitude/Amplitude-Python/assets/31029607/b9b2ca40-7077-4233-8ff2-93d446ba763e">


### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Python/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->