### PR TITLE
chore: fix semantic release package version

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -41,13 +41,13 @@ jobs:
       - name: Publish distribution PyPI --dry-run
         if: ${{ github.event.inputs.dryRun == 'true'}}
         run: |
-          python -m pip install python-semantic-release~=7.0.0
+          python -m pip install python-semantic-release==7.33.0
           semantic-release publish --noop
 
       - name: Publish distribution PyPI
         if: ${{ github.event.inputs.dryRun == 'false'}}
         run: |
-          python -m pip install python-semantic-release~=7.0.0
+          python -m pip install python-semantic-release==7.33.0
           git config user.name amplitude-sdk-bot
           git config user.email amplitude-sdk-bot@users.noreply.github.com
           semantic-release publish


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude Python SDK! 🐍

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

The previous fix https://github.com/amplitude/Amplitude-Python/pull/49 will install `7.34.6` which returns another `error: [Errno 2] No such file or directory: "['src/amplitude/constants.py"` when [build](https://github.com/amplitude/Amplitude-Python/actions/runs/5765488494/job/15631518091).

Try to fix the version as the one we ran with successfully last time 7 month ago.

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Python/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->