### PR TITLE
fix: set group should set user property

### DIFF
--- a/src/amplitude/client.py
+++ b/src/amplitude/client.py
@@ -128,7 +128,8 @@ class Amplitude:
             event_options (amplitude.event.EventOptions): Provide additional information for event
                 like user_id.
         """
-        event = IdentifyEvent(groups={group_type: group_name})
+        identify = Identify().set(group_type, group_name)
+        event = IdentifyEvent(groups={group_type: group_name}, user_properties=identify.user_properties)
         event.load_event_options(event_options)
         self.track(event)
 

--- a/src/test/test_client.py
+++ b/src/test/test_client.py
@@ -194,6 +194,7 @@ class AmplitudeClientTestCase(unittest.TestCase):
             self.assertEqual("test_user_id", event["user_id"])
             self.assertEqual("test_device_id", event["device_id"])
             self.assertEqual({"type": ["test_group", "test_group_2"]}, event.groups)
+            self.assertEqual({"$set": {"type": ["test_group", "test_group_2"]}}, event.user_properties)
 
         self.client.configuration.callback = callback_func
         for use_batch in (True, False):


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude Python SDK! 🐍

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

https://amplitude.atlassian.net/browse/AMP-83718

`set_group()` should set both `event.groups` and `event.user_properties`. 

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Python/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->