### PR TITLE
fix: adding currency property to events

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -30,10 +30,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up Python 3.7
+      - name: Set up Python 3.8
         uses: actions/setup-python@v3
         with:
-          python-version: 3.7
+          python-version: 3.8
 
       - name: Run Test
         run: python -m unittest discover -s ./src -p 'test_*.py'

--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -21,10 +21,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Set up Python 3.7
+      - name: Set up Python 3.8
         uses: actions/setup-python@v3
         with:
-          python-version: 3.7
+          python-version: 3.8
 
       - name: Install dependencies
         run: python -m pip install build setuptools wheel twine

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ "3.7", "3.8", "3.9", "3.10", "3.11" ]
+        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12", "3.13" ]
     steps:
       - name: Checkout source code
         uses: actions/checkout@v3

--- a/src/amplitude/constants.py
+++ b/src/amplitude/constants.py
@@ -40,6 +40,7 @@ REVENUE_TYPE = "$revenueType"
 REVENUE_RECEIPT = "$receipt"
 REVENUE_RECEIPT_SIG = "$receiptSig"
 REVENUE = "$revenue"
+REVENUE_CURRENCY = "$currency"
 AMP_REVENUE_EVENT = "revenue_amount"
 
 MAX_PROPERTY_KEYS = 1024

--- a/src/amplitude/event.py
+++ b/src/amplitude/event.py
@@ -145,6 +145,7 @@ EVENT_KEY_MAPPING = {
     "price": ["price", float],
     "quantity": ["quantity", int],
     "revenue": ["revenue", float],
+    "currency": ["currency", str],
     "product_id": ["productId", str],
     "revenue_type": ["revenueType", str],
     "location_lat": ["location_lat", float],
@@ -240,6 +241,7 @@ class EventOptions:
                  revenue: Optional[float] = None,
                  product_id: Optional[str] = None,
                  revenue_type: Optional[str] = None,
+                 currency: Optional[str] = None,
                  location_lat: Optional[float] = None,
                  location_lng: Optional[float] = None,
                  ip: Optional[str] = None,
@@ -277,6 +279,7 @@ class EventOptions:
         self.revenue: Optional[str] = None
         self.product_id: Optional[str] = None
         self.revenue_type: Optional[str] = None
+        self.currency: Optional[str] = None
         self.location_lat: Optional[float] = None
         self.location_lng: Optional[float] = None
         self.ip: Optional[str] = None
@@ -313,6 +316,7 @@ class EventOptions:
         self["revenue"] = revenue
         self["product_id"] = product_id
         self["revenue_type"] = revenue_type
+        self["currency"] = currency
         self["location_lat"] = location_lat
         self["location_lng"] = location_lng
         self["ip"] = ip
@@ -484,6 +488,7 @@ class BaseEvent(EventOptions):
                  revenue: Optional[float] = None,
                  product_id: Optional[str] = None,
                  revenue_type: Optional[str] = None,
+                 currency: Optional[str] = None,
                  location_lat: Optional[float] = None,
                  location_lng: Optional[float] = None,
                  ip: Optional[str] = None,
@@ -520,6 +525,7 @@ class BaseEvent(EventOptions):
                          revenue=revenue,
                          product_id=product_id,
                          revenue_type=revenue_type,
+                         currency=currency,
                          location_lat=location_lat,
                          location_lng=location_lng,
                          ip=ip,
@@ -1042,7 +1048,8 @@ class Revenue:
                  receipt: Optional[str] = None,
                  receipt_sig: Optional[str] = None,
                  properties: Optional[dict] = None,
-                 revenue: Optional[float] = None):
+                 revenue: Optional[float] = None,
+                 currency: Optional[str] = None):
         """The constructor of the Revenue class"""
         self.price: float = price
         self.quantity: int = quantity
@@ -1052,6 +1059,7 @@ class Revenue:
         self.receipt_sig: Optional[str] = receipt_sig
         self.properties: Optional[dict] = properties
         self.revenue: Optional[float] = revenue
+        self.currency: Optional[str] = currency
 
     def set_receipt(self, receipt: str, receipt_signature: str):
         """Set the receipt and signature
@@ -1098,7 +1106,8 @@ class Revenue:
                                  constants.REVENUE_TYPE: self.revenue_type,
                                  constants.REVENUE_RECEIPT: self.receipt,
                                  constants.REVENUE_RECEIPT_SIG: self.receipt_sig,
-                                 constants.REVENUE: self.revenue})
+                                 constants.REVENUE: self.revenue,
+                                 constants.REVENUE_CURRENCY: self.currency})
         return {key: value for key, value in event_properties.items() if value is not None}
 
 
@@ -1178,6 +1187,7 @@ class RevenueEvent(BaseEvent):
                  revenue: Optional[float] = None,
                  product_id: Optional[str] = None,
                  revenue_type: Optional[str] = None,
+                 currency: Optional[str] = None,
                  location_lat: Optional[float] = None,
                  location_lng: Optional[float] = None,
                  ip: Optional[str] = None,
@@ -1219,6 +1229,7 @@ class RevenueEvent(BaseEvent):
                          revenue=revenue,
                          product_id=product_id,
                          revenue_type=revenue_type,
+                         currency=currency,
                          location_lat=location_lat,
                          location_lng=location_lng,
                          ip=ip,

--- a/src/test/test_client.py
+++ b/src/test/test_client.py
@@ -36,7 +36,7 @@ class AmplitudeClientTestCase(unittest.TestCase):
             try:
                 self.assertEqual(200, code)
                 events.append(event.event_properties["id"])
-                self.assertEqual('AUD', event.currency)
+                self.assertEqual('USD', event.currency)
             except AssertionError as e:
                 self.assertion_errors.append(str(e))
 


### PR DESCRIPTION
### Summary

- Adding currency property to our events
- I noticed that exceptions in callbacks weren't causing the test to fail. So fixing that as well.

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Python/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->