### PR TITLE
chore: SECENG-7706 [security] Pin versions of GitHub Actions to full commit hash - quotation fix

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: ${{ github.actor }} permission check to do a release
-        uses: "lannonbr/repo-permission-check-action@2.0.2"
+        uses: "lannonbr/repo-permission-check-action@2bb8c89ba8bf115c4bfab344d6a6f442b24c9a1f" # 2.0.2
         with:
           permission: "write"
         env:

--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: ${{ github.actor }} permission check to do a release
-        uses: "lannonbr/repo-permission-check-action@2.0.2"
+        uses: "lannonbr/repo-permission-check-action@2bb8c89ba8bf115c4bfab344d6a6f442b24c9a1f" # 2.0.2
         with:
           permission: "write"
         env:


### PR DESCRIPTION
This PR pins versions of GitHub Actions to full commit hash via [automated scripts](https://github.com/amplitude/tools/tree/master/seceng/github_actions/pin-gha).
This PR fixes an error with the previous script not correctly parsing lines in "" quotations.
In general, this PR doesn't change the behavior of the workflows, so you can merge this safely.

This pull request was created by [multi-gitter](https://github.com/lindell/multi-gitter).

Please merge this pull request by 4/10/2026.

For any questions, please ask in the Slack channel #help-security.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates GitHub Actions workflow references to a pinned commit SHA, with no logic changes to the build/publish steps.
> 
> **Overview**
> Pins `lannonbr/repo-permission-check-action` to a full commit SHA in both `publish-to-pypi.yml` and `publish-to-test-pypi.yml` (replacing the `@2.0.2` tag) to harden the release authorization step against tag retargeting.
> 
> No other workflow behavior is changed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 571f305db57135f7d9c63980a1ab68b548778f0b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->